### PR TITLE
Add denoiser options and CPU denoise for final renders

### DIFF
--- a/engine/gfx/include/lucent/gfx/FinalRender.h
+++ b/engine/gfx/include/lucent/gfx/FinalRender.h
@@ -26,6 +26,9 @@ struct FinalRenderConfig {
     float exposure = 1.0f;
     TonemapOperator tonemap = TonemapOperator::ACES;
     float gamma = 2.2f;
+    DenoiserType denoiser = DenoiserType::None;
+    float denoiseStrength = 0.5f;
+    uint32_t denoiseRadius = 2;
     std::string outputPath = "render.png";
     bool useRayTracing = true;  // Use RayTraced if available, else Traced
 };
@@ -110,5 +113,4 @@ private:
 };
 
 } // namespace lucent::gfx
-
 

--- a/engine/gfx/include/lucent/gfx/RenderSettings.h
+++ b/engine/gfx/include/lucent/gfx/RenderSettings.h
@@ -25,6 +25,28 @@ inline const char* TonemapOperatorName(TonemapOperator op) {
     }
 }
 
+// Denoiser backends (viewport/final render)
+enum class DenoiserType : uint8_t {
+    None = 0,
+    Box,
+    EdgeAware,
+    OpenImageDenoise,
+    OptiX,
+    NRD
+};
+
+inline const char* DenoiserTypeName(DenoiserType type) {
+    switch (type) {
+        case DenoiserType::None:             return "None";
+        case DenoiserType::Box:              return "Box Blur";
+        case DenoiserType::EdgeAware:        return "Edge-Aware";
+        case DenoiserType::OpenImageDenoise: return "OpenImageDenoise";
+        case DenoiserType::OptiX:            return "OptiX";
+        case DenoiserType::NRD:              return "NRD";
+        default:                             return "Unknown";
+    }
+}
+
 // Blender-like render settings shared by all render modes
 struct RenderSettings {
     // === Sampling ===
@@ -48,8 +70,9 @@ struct RenderSettings {
     float gamma = 2.2f;
     
     // === Denoise ===
-    bool enableDenoise = false;
+    DenoiserType denoiser = DenoiserType::None;
     float denoiseStrength = 0.5f;
+    uint32_t denoiseRadius = 2;
     
     // === Performance ===
     bool useHalfRes = false;            // Render at half resolution for viewport
@@ -98,5 +121,4 @@ struct RenderSettings {
 };
 
 } // namespace lucent::gfx
-
 


### PR DESCRIPTION
### Motivation
- Provide selectable denoiser backends and tuning parameters so users can choose between lightweight CPU denoisers and placeholders for external/accelerated backends.
- Implement a basic denoising path for exported/final renders to improve image quality immediately without external deps.
- Surface denoiser controls in the editor UI where previously denoising was marked as "(Not yet implemented)".

### Description
- Added a `DenoiserType` enum and helper `DenoiserTypeName` and replaced the old simple flag with `RenderSettings::denoiser`, `denoiseStrength`, and `denoiseRadius` in `engine/gfx/include/lucent/gfx/RenderSettings.h`.
- Extended `FinalRenderConfig` with denoiser fields (`denoiser`, `denoiseStrength`, `denoiseRadius`) in `engine/gfx/include/lucent/gfx/FinalRender.h`.
- Implemented CPU `BoxDenoise` and `EdgeAwareDenoise` functions and integrated denoising into the final-render readback/tonemap path in `engine/gfx/src/FinalRender.cpp` with strength/radius blending.
- Exposed denoiser selection and controls (`Denoiser`, `Strength`, `Radius`) in the render properties UI and disabled/annotated options that require external integrations in `app/editor/src/EditorUI.cpp`.

### Testing
- No automated tests were run on these changes.
- Manual build/run was not performed as part of this change (no CI triggered by this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea0e80a70832ca11eb36a7573f472)