### PR TITLE
Add architecture, editor workflow, and rendering documentation; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,43 @@
 # Lucent
 
-A Blender-like 3D editor with a Cycles-style progressive Vulkan ray-traced path tracer.
+**Lucent** is an early-stage 3D editor built on Vulkan, with a modern docking UI, realtime shading, and a progressive ray/path tracing pipeline in development. It targets creators who want a fast, GPU-first workspace for scene layout, materials, and lighting.
 
-## Features (Planned)
+> **Status:** Alpha (Windows-only). Expect rapid iteration and breaking changes.
 
-- **Modern 3D Editor**: Scene outliner, viewport, gizmos, selection, transforms
-- **Dual Viewport Modes**: Fast raster preview + progressive path-traced viewport
-- **Vulkan Ray Tracing**: KHR ray tracing extensions for hardware-accelerated path tracing
-- **Material Node Editor**: Node-based material system compiling to GPU shaders
-- **High Performance**: GPU-first rendering, stable frame pacing, incremental scene updates
+## Highlights
+
+- **Docking editor UI** with Viewport, Outliner, Inspector, Content Browser, Console, Render Properties, and Material Graph panels.
+- **Scene authoring** with primitives, cameras, and lights, plus selection and gizmo-based transforms.
+- **Material graph editor** with on-demand compilation and asset management.
+- **Progressive rendering modes** (Simple, Traced, Ray Traced) with sampling, denoising, and film controls.
+- **Asset pipeline** with an `Assets/` workspace, import tools, and `.lucent` scene files.
+
+## Current Progress
+
+**Ready today**
+- Docking editor shell and core panels.
+- Primitive creation (cube, sphere, plane, cylinder, cone) and basic lighting (point, directional, spot).
+- Scene save/load to the `.lucent` format.
+- Content Browser with search, folder tools, and drag/drop asset workflows.
+- Material Graph with `.lmat` assets stored in `Assets/materials`.
+- Render Properties for sampling, denoise, exposure, tonemapping, and gamma.
+
+**In flight**
+- Production-ready ray/path tracing workflows and higher-level asset import.
+- Expanded node library, material authoring, and external format interoperability.
 
 ## Requirements
 
-- **OS**: Windows 10/11 (64-bit)
-- **GPU**: NVIDIA RTX 2000+ or AMD RX 6000+ (Vulkan 1.3 required, RT optional)
-- **Vulkan SDK**: 1.3.x or later
-- **Build Tools**: CMake 3.25+, MSVC 2022, vcpkg
+- **OS:** Windows 10/11 (64-bit)
+- **GPU:** Vulkan 1.3 capable GPU (RTX 2000+ / RX 6000+ recommended for ray tracing)
+- **Vulkan SDK:** 1.3.x or later
+- **Build Tools:** CMake 3.25+, MSVC 2022, vcpkg
 
-## Quick Start (Windows Only)
+## Quick Start (Windows)
 
-> **Note**: This project currently targets Windows only. Build in Windows PowerShell, not WSL.
-
-### Prerequisites
-
-1. Visual Studio 2022 with C++ workload
-2. [Vulkan SDK 1.3+](https://vulkan.lunarg.com/sdk/home)
-3. [vcpkg](https://github.com/microsoft/vcpkg) with `VCPKG_ROOT` environment variable set
-
-### Build
+> Build in Windows PowerShell (not WSL).
 
 ```powershell
-# In Windows PowerShell (NOT WSL)
-
 # Verify vcpkg is configured
 echo $env:VCPKG_ROOT  # Should print your vcpkg path
 
@@ -48,35 +54,79 @@ cd ..
 ./build/debug/bin/Debug/editor.exe
 ```
 
+## App Documentation
+
+### Workspace Overview
+
+- **Viewport:** The realtime preview where you orbit, select, and manipulate entities.
+- **Outliner:** Hierarchical list of scene entities. Right-click for create/duplicate/delete.
+- **Inspector:** Edit transforms, mesh renderer, light, and camera components.
+- **Content Browser:** Manage `Assets/` (search, folders, drag/drop).
+- **Material Graph:** Node editor for `.lmat` materials with compile status.
+- **Render Properties:** Configure render modes, samples, bounces, denoise, and film settings.
+- **Console:** Diagnostics and status messages.
+
+Open panels from **View → Panels** and reset the layout from **View → Reset Layout**.
+
+### Navigation & Selection
+
+- **Orbit:** Right-click + drag
+- **Pan:** Middle-click + drag
+- **Zoom:** Scroll wheel
+- **Focus selection:** `F`
+- **Select:** Left-click (use `Ctrl`/`Shift` for multi-select)
+
+### Transform Tools
+
+- **Move:** `W`
+- **Rotate:** `E`
+- **Scale:** `R`
+- **Toggle snapping:** Hold `Ctrl`
+
+### Scene Workflow
+
+1. **Create entities:** Use **Create** menu or Outliner context menu.
+2. **Edit transforms and components:** Use the Inspector panel.
+3. **Assign materials:** Drag a `.lmat` material from the Content Browser onto a mesh in the Viewport.
+4. **Save/Open scenes:** `Ctrl+S` / `Ctrl+O` to work with `.lucent` files.
+
+### Assets & File Formats
+
+- **Scenes:** `.lucent` files (Lucent scene format).
+- **Materials:** `.lmat` files stored in `Assets/materials`.
+- **Imported assets:** Use **File → Import** to copy images or `.obj` files into `Assets/`.
+
+### Rendering Controls
+
+Use **Render Properties** to switch modes and tune quality:
+
+- **Simple:** Fast raster preview.
+- **Traced / Ray Traced:** Progressive modes with sample accumulation (GPU dependent).
+- **Sampling:** Viewport samples, final samples, half-resolution.
+- **Denoise:** Box/Edge-aware and optional OptiX (when available).
+- **Film:** Exposure, tonemapping, and gamma.
+
+### Keyboard Shortcuts (Quick Reference)
+
+| Action | Shortcut |
+| --- | --- |
+| New Scene | `Ctrl+N` |
+| Open Scene | `Ctrl+O` |
+| Save Scene | `Ctrl+S` |
+| Save Scene As | `Ctrl+Shift+S` |
+| Duplicate | `Ctrl+D` |
+| Undo / Redo | `Ctrl+Z` / `Ctrl+Y` |
+| Delete | `Delete` |
+| Select All | `Ctrl+A` |
+
 ## Project Structure
 
 ```
-lucent/
-├── app/
-│   └── editor/          # Main editor application
-├── engine/
-│   ├── core/            # Logging, assertions, utilities
-│   ├── gfx/             # Vulkan abstraction layer
-│   ├── rt/              # Ray tracing (Milestone F+)
-│   ├── scene/           # ECS / scene graph (Milestone C+)
-│   ├── assets/          # Asset pipeline (Milestone D+)
-│   └── material/        # Node material system (Milestone L+)
-├── shaders/             # GLSL shaders
-├── docs/
-│   └── milestones/      # Per-milestone documentation
-└── tests/               # Unit tests
+app/            # Editor application
+engine/         # Core engine (gfx, scene, material, assets)
+shaders/        # GLSL shaders
+docs/           # Developer documentation
 ```
-
-## Milestone Progress
-
-- [x] **Milestone A**: Foundations (Boot to Triangle)
-- [ ] **Milestone B**: Editor Shell (ImGui docking)
-- [ ] **Milestone C**: Scene System + Gizmos
-- [ ] **Milestone D**: Asset Pipeline v1 (glTF)
-- [ ] **Milestone E**: PBR Raster Viewport
-- [ ] **Milestone F**: Vulkan RT Core
-- [ ] **Milestone G**: RT Scene Sync (BLAS/TLAS)
-- [ ] **Milestone H**: Path Tracer v1
 
 ## Documentation
 
@@ -90,7 +140,6 @@ TBD
 
 - Vulkan SDK by LunarG
 - GLFW for windowing
-- ImGui for UI (upcoming)
+- ImGui + ImGuizmo for UI
 - glm for math
 - spdlog for logging
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Lucent Documentation
+
+This folder contains deeper documentation for Lucent’s architecture, editor workflow, and rendering pipeline. Start here if you want to understand how the editor is organized or how to extend it.
+
+## Guides
+
+- [Architecture Overview](architecture.md)
+- [Editor Workflow & UX](editor_workflow.md)
+- [Rendering Pipeline](rendering.md)
+
+## Milestones
+
+- [Milestone A: Foundations](milestones/A_foundations.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,67 @@
+# Architecture Overview
+
+Lucent is split into two major layers: the **editor app** (UI + tooling) and the **engine** (rendering, scene, and asset systems). The project is organized to keep editor concerns isolated while sharing engine modules across future tools.
+
+## Top-Level Layout
+
+```
+app/        # Editor UI and interaction layer
+engine/     # Core engine systems
+shaders/    # GLSL + shader build scripts
+assets/     # Runtime asset workspace (created at runtime)
+docs/       # Documentation and milestones
+```
+
+## Editor App (app/editor)
+
+**Primary responsibilities**
+- Windowing + input (GLFW).
+- Docking UI (ImGui + ImGuizmo).
+- Scene editing workflow and user interactions.
+- File dialogs, scene I/O, and content browsing.
+
+**Key modules**
+- `app/editor/src/Application.cpp`
+  - Owns the main loop, Vulkan context, device, renderer, UI, and scene.
+  - Initializes demo content, hooks editor camera, and passes render data.
+- `app/editor/src/EditorUI.cpp`
+  - Builds the dockspace, menus, panels, and modal dialogs.
+  - Manages editor state (selection, gizmos, content browser, render settings UI).
+- `app/editor/src/SceneIO.cpp`
+  - Reads/writes `.lucent` scene files.
+- `app/editor/src/MaterialGraphPanel.cpp`
+  - Node editor UI for `.lmat` materials, compilation status, and editing.
+
+## Engine (engine/)
+
+The engine layer is organized into focused modules with minimal UI dependencies.
+
+- `engine/gfx/`
+  - Vulkan context/device management.
+  - Swapchain, renderer, render settings, and render modes.
+  - Final presentation path and feature capability detection.
+- `engine/scene/`
+  - ECS-style scene representation (entities + components).
+  - Transform, camera, light, mesh renderer components.
+- `engine/material/`
+  - Material graph definition, compiler, asset management.
+  - `.lmat` serialization and compilation into Vulkan pipelines.
+- `engine/assets/`
+  - Asset helpers and primitive mesh generation.
+- `engine/core/`
+  - Logging, assertions, and shared utilities.
+
+## Data Flow (High Level)
+
+1. **Editor UI** captures user intent (menus, gizmos, selection changes).
+2. **Scene** is updated (entities/components/transform).
+3. **Renderer** consumes the scene + render settings each frame.
+4. **Material system** compiles graph changes into GPU pipelines.
+5. **Output** is presented in the viewport and synchronized to UI panels.
+
+## Extension Points
+
+- **New panels:** Implement in `EditorUI.cpp`, add to the View menu and dock layout.
+- **New components:** Add to `engine/scene`, then expose in the Inspector panel.
+- **Render modes:** Extend `engine/gfx` and surface controls in Render Properties.
+- **Material nodes:** Add node definitions and compiler rules in `engine/material`.

--- a/docs/editor_workflow.md
+++ b/docs/editor_workflow.md
@@ -1,0 +1,63 @@
+# Editor Workflow & UX
+
+This guide explains how the Lucent editor works today, including panels, workflows, and how the UI is structured.
+
+## Core Panels
+
+- **Viewport**
+  - Primary scene view and interaction surface.
+  - Orbit, pan, zoom, and select entities.
+  - Drag `.lmat` materials from the Content Browser onto meshes.
+- **Outliner**
+  - Hierarchical view of all entities in the scene.
+  - Context menu for creating primitives and lights.
+- **Inspector**
+  - Per-entity component editor.
+  - Supports transforms, mesh renderer settings, light and camera settings.
+- **Content Browser**
+  - Asset management for the `Assets/` workspace.
+  - Search, create folders, drag-and-drop assets.
+- **Material Graph**
+  - Node editor for `.lmat` materials.
+  - Compile status, save state, and material assignment.
+- **Render Properties**
+  - Render mode selection and quality tuning (samples, bounces, denoise, film).
+- **Console**
+  - Diagnostics and system messages.
+
+## Layout & Docking
+
+The editor uses ImGui docking. Panels can be rearranged or reset via:
+
+- **View → Reset Layout**
+- **View → Save Layout**
+
+## Scene Workflow (Recommended)
+
+1. **Create a scene** via `File → New Scene`.
+2. **Add entities** in the Create menu or Outliner context menu.
+3. **Transform entities** with gizmos (`W`, `E`, `R`).
+4. **Assign materials** by dragging `.lmat` files onto meshes in the Viewport.
+5. **Tune rendering** in Render Properties.
+6. **Save** to a `.lucent` file.
+
+## Selection Model
+
+- **Single select:** Left-click.
+- **Toggle select:** `Ctrl` + click.
+- **Add select:** `Shift` + click.
+- **Select all:** `Ctrl+A`.
+
+## Keyboard Shortcuts (Quick Reference)
+
+| Action | Shortcut |
+| --- | --- |
+| New Scene | `Ctrl+N` |
+| Open Scene | `Ctrl+O` |
+| Save Scene | `Ctrl+S` |
+| Save Scene As | `Ctrl+Shift+S` |
+| Undo / Redo | `Ctrl+Z` / `Ctrl+Y` |
+| Duplicate | `Ctrl+D` |
+| Delete | `Delete` |
+| Focus | `F` |
+| Move / Rotate / Scale | `W` / `E` / `R` |

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -1,0 +1,53 @@
+# Rendering Pipeline
+
+Lucent supports multiple render modes that trade speed for quality. The renderer is built on Vulkan and can run either a fast raster path or progressive traced modes when supported by the GPU.
+
+## Render Modes
+
+- **Simple**
+  - Fast raster preview for editing and layout.
+- **Traced**
+  - Progressive path tracing (software or hybrid pipeline, GPU dependent).
+- **Ray Traced**
+  - Hardware-accelerated path tracing (requires Vulkan ray tracing support).
+
+These modes are surfaced in the **Render Properties** panel and synchronized with engine capabilities.
+
+## Render Settings
+
+The Render Properties panel allows tuning parameters:
+
+- **Sampling**
+  - Viewport samples (progressive accumulation).
+  - Final samples (high quality output).
+  - Max frame time (progressive budget).
+  - Half-resolution toggle for performance.
+- **Light Paths** (Traced/Ray Traced)
+  - Max bounces and per-lobe bounce limits (diffuse/specular/transmission).
+- **Clamping**
+  - Direct and indirect clamp values to control fireflies.
+- **Film**
+  - Exposure, tonemapping, and gamma.
+- **Denoise**
+  - Box and edge-aware denoise are built-in.
+  - OptiX denoise can be enabled when available.
+
+## Material Integration
+
+Materials are authored in the Material Graph editor as `.lmat` assets and compiled into Vulkan pipelines. The material system is responsible for:
+
+- Graph serialization and file I/O (`Assets/materials`).
+- Shader compilation from nodes to SPIR-V.
+- Pipeline creation and caching.
+
+## Progressive Updates
+
+Traced render modes accumulate samples over time. Camera movement, edits, and material changes invalidate accumulation to keep the viewport responsive.
+
+## Future Work
+
+Planned rendering improvements include:
+
+- GPU light transport optimizations.
+- Expanded denoiser integrations.
+- Final frame render pipeline and export.


### PR DESCRIPTION
### Motivation

- Provide deeper developer and user-facing documentation describing the editor, engine, and rendering internals to improve onboarding and extensibility.  
- Surface current editor capabilities, status, and quick start steps in the top-level `README` so contributors can build and run the project.  
- Capture editor UX, panel responsibilities, transform/selection model, and asset workflows for consistent usage.  
- Document rendering modes, settings, and material integration so implementers understand runtime data flow and extension points.

### Description

- Expanded `README.md` with an explicit status line, highlights, Windows `Quick Start`, `App Documentation` (panels, navigation, tools), assets, and rendering controls.  
- Added a `docs/` landing page and three new guides: `docs/architecture.md` describing top-level layout, editor vs engine responsibilities, data flow, and extension points.  
- Added `docs/editor_workflow.md` documenting panels, layout/docking, scene workflow, selection model, and keyboard shortcuts.  
- Added `docs/rendering.md` outlining render modes (`Simple`, `Traced`, `Ray Traced`), render settings, material integration, progressive updates, and future work.

### Testing

- No automated tests were executed because this is a documentation-only change.  
- Manual verification: files were created under `docs/` and the `README.md` changes were inspected for completeness.  
- No build or runtime changes were made, so the codebase build was not affected.  
- No test failures introduced by these documentation edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb32e2e50832c90cfa03232ad3532)