### PR TITLE
F12 final render capture + render resolution & transparent background

### DIFF
--- a/app/editor/include/Application.h
+++ b/app/editor/include/Application.h
@@ -108,6 +108,11 @@ private:
     void UpdateTracerLightsOnly();
     void RenderTracedPath(VkCommandBuffer cmd);
     void RenderRayTracedPath(VkCommandBuffer cmd);
+    void BuildTracerSceneData(std::vector<gfx::BVHBuilder::Triangle>& triangles,
+                              std::vector<gfx::GPUMaterial>& materials,
+                              std::vector<gfx::GPULight>& lights,
+                              std::vector<gfx::GPUVolume>& volumes);
+    void StartFinalRenderFromMainCamera();
     bool m_TracerSceneDirty = true;
     std::vector<gfx::GPULight> m_LastTracerLights;
     
@@ -117,4 +122,3 @@ private:
 };
 
 } // namespace lucent
-

--- a/engine/gfx/include/lucent/gfx/FinalRender.h
+++ b/engine/gfx/include/lucent/gfx/FinalRender.h
@@ -31,6 +31,7 @@ struct FinalRenderConfig {
     uint32_t denoiseRadius = 2;
     std::string outputPath = "render.png";
     bool useRayTracing = true;  // Use RayTraced if available, else Traced
+    bool transparentBackground = false;
 };
 
 // Render progress callback
@@ -57,7 +58,9 @@ public:
     // Start a render job
     bool Start(const FinalRenderConfig& config, const GPUCamera& camera,
                const std::vector<BVHBuilder::Triangle>& triangles,
-               const std::vector<GPUMaterial>& materials);
+               const std::vector<GPUMaterial>& materials,
+               const std::vector<GPULight>& lights = {},
+               const std::vector<GPUVolume>& volumes = {});
     
     // Cancel current render
     void Cancel();
@@ -113,4 +116,3 @@ private:
 };
 
 } // namespace lucent::gfx
-

--- a/engine/gfx/include/lucent/gfx/RenderSettings.h
+++ b/engine/gfx/include/lucent/gfx/RenderSettings.h
@@ -53,7 +53,12 @@ struct RenderSettings {
     uint32_t viewportSamples = 32;      // Max samples for viewport (progressive)
     uint32_t finalSamples = 128;        // Samples for final render
     uint32_t minSamples = 1;            // Minimum samples before converge check
-    
+
+    // === Output ===
+    uint32_t renderWidth = 1920;        // Final render width
+    uint32_t renderHeight = 1080;       // Final render height
+    bool transparentBackground = false; // Render with transparent background
+
     // === Bounces ===
     uint32_t maxBounces = 4;            // Total max bounces
     uint32_t diffuseBounces = 4;        // Max diffuse bounces
@@ -129,4 +134,3 @@ struct RenderSettings {
 };
 
 } // namespace lucent::gfx
-

--- a/engine/gfx/include/lucent/gfx/TracerCompute.h
+++ b/engine/gfx/include/lucent/gfx/TracerCompute.h
@@ -115,10 +115,10 @@ struct TracerPushConstants {
     float envIntensity;
     float envRotation;
     uint32_t useEnvMap;
+    uint32_t transparentBackground;
     uint32_t volumeCount;  // Number of volume instances
     uint32_t pad0;
     uint32_t pad1;
-    uint32_t pad2;
 };
 
 // Scene data for GPU
@@ -247,4 +247,3 @@ private:
 };
 
 } // namespace lucent::gfx
-

--- a/engine/gfx/include/lucent/gfx/TracerRayKHR.h
+++ b/engine/gfx/include/lucent/gfx/TracerRayKHR.h
@@ -67,10 +67,10 @@ struct RTPushConstants {
     float envIntensity;
     float envRotation;
     uint32_t useEnvMap;
+    uint32_t transparentBackground;
     uint32_t volumeCount;
     uint32_t pad0;
     uint32_t pad1;
-    uint32_t pad2;
 };
 
 // Vulkan KHR ray tracing based path tracer
@@ -203,5 +203,4 @@ private:
 };
 
 } // namespace lucent::gfx
-
 

--- a/engine/gfx/src/TracerCompute.cpp
+++ b/engine/gfx/src/TracerCompute.cpp
@@ -783,6 +783,7 @@ void TracerCompute::Trace(VkCommandBuffer cmd,
     pc.envIntensity = settings.envIntensity;
     pc.envRotation = settings.envRotation;
     pc.useEnvMap = (m_EnvMap && m_EnvMap->IsLoaded() && settings.useEnvMap) ? 1 : 0;
+    pc.transparentBackground = settings.transparentBackground ? 1 : 0;
     pc.volumeCount = m_SceneGPU.volumeCount;
     
     vkCmdPushConstants(cmd, m_PipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT, 
@@ -840,4 +841,3 @@ void TracerCompute::ResetAccumulation() {
 }
 
 } // namespace lucent::gfx
-

--- a/engine/gfx/src/TracerRayKHR.cpp
+++ b/engine/gfx/src/TracerRayKHR.cpp
@@ -1343,6 +1343,7 @@ void TracerRayKHR::Trace(VkCommandBuffer cmd,
     pc.envIntensity = settings.envIntensity;
     pc.envRotation = settings.envRotation;
     pc.useEnvMap = (m_EnvMap && m_EnvMap->IsLoaded() && settings.useEnvMap) ? 1 : 0;
+    pc.transparentBackground = settings.transparentBackground ? 1 : 0;
     pc.volumeCount = m_VolumeCount;
     
     vkCmdPushConstants(cmd, m_PipelineLayout, 
@@ -1404,5 +1405,4 @@ void TracerRayKHR::SetEnvironmentMap(EnvironmentMap* envMap) {
 }
 
 } // namespace lucent::gfx
-
 

--- a/shaders/rt_raygen.rgen
+++ b/shaders/rt_raygen.rgen
@@ -59,10 +59,10 @@ layout(push_constant) uniform PushConstants {
     float envIntensity;
     float envRotation;
     uint useEnvMap;
+    uint transparentBackground;
     uint volumeCount;
     uint pad0;
     uint pad1;
-    uint pad2;
 } pc;
 
 // Ray payload: carries radiance, throughput, hit info for multi-bounce
@@ -220,6 +220,7 @@ void main() {
     vec3 firstHitAlbedo = vec3(0.0);
     vec3 firstHitNormal = vec3(0.0);
     bool capturedAOV = false;
+    bool hitPrimary = false;
     
     for (uint bounce = 0; bounce <= pc.maxBounces; bounce++) {
         // Initialize payload
@@ -240,12 +241,19 @@ void main() {
         if (!payload.hit) {
             // Miss - add sky contribution
             vec3 skyColor = getSkyColor(direction);
-            radiance += throughput * skyColor;
+            if (pc.transparentBackground == 0u || bounce > 0u) {
+                radiance += throughput * skyColor;
+            }
             
             // For sky hits on first bounce, use sky as albedo
             if (!capturedAOV) {
-                firstHitAlbedo = skyColor;
-                firstHitNormal = -direction * 0.5 + 0.5;  // Remap to [0,1]
+                if (pc.transparentBackground == 0u) {
+                    firstHitAlbedo = skyColor;
+                    firstHitNormal = -direction * 0.5 + 0.5;  // Remap to [0,1]
+                } else {
+                    firstHitAlbedo = vec3(0.0);
+                    firstHitNormal = vec3(0.5);
+                }
             }
             break;
         }
@@ -259,6 +267,9 @@ void main() {
                 firstHitAlbedo = payload.volumeColor;
                 firstHitNormal = vec3(0.5); // neutral
                 capturedAOV = true;
+            }
+            if (bounce == 0u) {
+                hitPrimary = true;
             }
 
             origin = payload.volumeExitPos + direction * 0.001;
@@ -275,6 +286,9 @@ void main() {
             firstHitAlbedo = payload.albedo;
             firstHitNormal = payload.hitNormal * 0.5 + 0.5;  // Remap to [0,1]
             capturedAOV = true;
+        }
+        if (bounce == 0u) {
+            hitPrimary = true;
         }
         
         // Add emissive contribution
@@ -414,7 +428,9 @@ void main() {
     vec4 prevColor = imageLoad(accumImage, ivec2(pixel));
     float sampleWeight = 1.0 / float(pc.sampleIndex + 1);
     vec3 accumulated = mix(prevColor.rgb, radiance, sampleWeight);
-    imageStore(accumImage, ivec2(pixel), vec4(accumulated, 1.0));
+    float sampleAlpha = (pc.transparentBackground != 0u && !hitPrimary) ? 0.0 : 1.0;
+    float accumulatedAlpha = mix(prevColor.a, sampleAlpha, sampleWeight);
+    imageStore(accumImage, ivec2(pixel), vec4(accumulated, accumulatedAlpha));
     
     // Accumulate AOVs (albedo and normal - these converge quickly)
     vec4 prevAlbedo = imageLoad(albedoImage, ivec2(pixel));
@@ -424,4 +440,3 @@ void main() {
     imageStore(albedoImage, ivec2(pixel), vec4(accumAlbedo, 1.0));
     imageStore(normalImage, ivec2(pixel), vec4(accumNormal, 1.0));
 }
-

--- a/shaders/traced.comp
+++ b/shaders/traced.comp
@@ -92,10 +92,10 @@ layout(push_constant) uniform PushConstants {
     float envIntensity;
     float envRotation;
     uint useEnvMap;
+    uint transparentBackground;
     uint volumeCount;
     uint pad0;
     uint pad1;
-    uint pad2;
 } pc;
 
 // Light types
@@ -456,6 +456,7 @@ struct PathTraceResult {
     vec3 radiance;
     vec3 albedo;   // First-hit albedo for denoiser
     vec3 normal;   // First-hit normal for denoiser
+    bool hitPrimary;
 };
 
 // Path trace
@@ -464,6 +465,7 @@ PathTraceResult pathTrace(Ray ray, inout uint seed) {
     result.radiance = vec3(0.0);
     result.albedo = vec3(0.0);
     result.normal = vec3(0.0);
+    result.hitPrimary = false;
     
     vec3 throughput = vec3(1.0);
     bool firstHit = true;
@@ -483,6 +485,10 @@ PathTraceResult pathTrace(Ray ray, inout uint seed) {
                 // Apply volume contribution with premultiplied alpha
                 result.radiance += throughput * volResult.rgb;
                 throughput *= (1.0 - volResult.a);
+
+                if (firstHit) {
+                    result.hitPrimary = true;
+                }
                 
                 // If volume is opaque, stop tracing
                 if (volResult.a > 0.99) {
@@ -499,12 +505,19 @@ PathTraceResult pathTrace(Ray ray, inout uint seed) {
             // Sky color (simple gradient)
             // Sample environment map
             vec3 envColor = sampleEnvironment(ray.direction);
-            result.radiance += throughput * envColor;
+            if (pc.transparentBackground == 0u || !firstHit) {
+                result.radiance += throughput * envColor;
+            }
             
             // For sky hits on first bounce, use env as albedo
             if (firstHit) {
-                result.albedo = envColor;
-                result.normal = -ray.direction;  // Normal pointing back at camera
+                if (pc.transparentBackground == 0u) {
+                    result.albedo = envColor;
+                    result.normal = -ray.direction;  // Normal pointing back at camera
+                } else {
+                    result.albedo = vec3(0.0);
+                    result.normal = vec3(0.5);
+                }
             }
             break;
         }
@@ -526,6 +539,7 @@ PathTraceResult pathTrace(Ray ray, inout uint seed) {
         
         // Capture first-hit AOVs for denoiser
         if (firstHit) {
+            result.hitPrimary = true;
             result.albedo = baseColor.rgb;
             result.normal = normal * 0.5 + 0.5;  // Remap to [0,1] for storage
             firstHit = false;
@@ -684,7 +698,9 @@ void main() {
     vec4 prevColor = imageLoad(accumImage, pixelCoord);
     float sampleWeight = 1.0 / float(pc.sampleIndex + 1);
     vec3 accumulated = mix(prevColor.rgb, result.radiance, sampleWeight);
-    imageStore(accumImage, pixelCoord, vec4(accumulated, 1.0));
+    float sampleAlpha = (pc.transparentBackground != 0u && !result.hitPrimary) ? 0.0 : 1.0;
+    float accumulatedAlpha = mix(prevColor.a, sampleAlpha, sampleWeight);
+    imageStore(accumImage, pixelCoord, vec4(accumulated, accumulatedAlpha));
     
     // Accumulate AOVs (albedo and normal - these converge quickly)
     vec4 prevAlbedo = imageLoad(albedoImage, pixelCoord);
@@ -694,4 +710,3 @@ void main() {
     imageStore(albedoImage, pixelCoord, vec4(accumAlbedo, 1.0));
     imageStore(normalImage, pixelCoord, vec4(accumNormal, 1.0));
 }
-


### PR DESCRIPTION
### Motivation

- Provide a Blender-like final render workflow: allow rendering a single high-quality image from the scene's primary camera via `F12`.
- Let users control final render output resolution and whether the background should be transparent.
- Reuse existing tracer pipelines and scene collection so final renders match the viewport/traced outputs.
- Preserve alpha through accumulation and tonemapping so saved images can include transparency when requested.

### Description

- Added output settings to `RenderSettings`: `renderWidth`, `renderHeight`, and `transparentBackground`, and exposed them in the UI under an `Output` panel with `Render Resolution` and `Transparent Background` controls (`app/editor/src/EditorUI.cpp`).
- Implemented an `F12` handler that starts a final render from the primary camera via `StartFinalRenderFromMainCamera()`, collects scene data with `BuildTracerSceneData(...)`, and drives a `FinalRender` job (`app/editor/src/Application.cpp`, `app/editor/include/Application.h`).
- Propagated `transparentBackground` through push constants (`TracerPushConstants` / `RTPushConstants`) and into both tracing backends, and updated shaders to accumulate alpha and omit sky contribution when transparency is requested (`engine/gfx/include/...`, `engine/gfx/src/...`, `shaders/traced.comp`, `shaders/rt_raygen.rgen`).
- Extended `FinalRender` to accept lights/volumes, forward `transparentBackground` into per-sample `RenderSettings`, preserve per-pixel alpha during CPU tonemapping/readback, and expose a small final-render UI to view progress, cancel, and save results (`engine/gfx/include/lucent/gfx/FinalRender.h`, `engine/gfx/src/FinalRender.cpp`, `app/editor/src/EditorUI.cpp`).

### Testing

- No automated tests were run as part of this change.
- Basic integration: final render sampling is executed each frame when a `FinalRender` job is active via `RenderSample()` in the main loop (no runtime binary tests executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa6b89214832cb50c0f2f6126196d)