### PR TITLE
Show splash logo during Windows editor startup and delay main window reveal

### DIFF
--- a/app/editor/include/Application.h
+++ b/app/editor/include/Application.h
@@ -46,6 +46,10 @@ public:
     
 private:
     bool InitWindow(const ApplicationConfig& config);
+#ifdef _WIN32
+    void ShowSplashScreen();
+    void HideSplashScreen();
+#endif
     void InitScene();
     void ProcessInput();
     void RenderFrame();
@@ -60,6 +64,11 @@ private:
 private:
     GLFWwindow* m_Window = nullptr;
     ApplicationConfig m_Config;
+
+#ifdef _WIN32
+    void* m_SplashWindow = nullptr;
+    void* m_SplashIcon = nullptr;
+#endif
     
     gfx::VulkanContext m_VulkanContext;
     gfx::Device m_Device;


### PR DESCRIPTION
### Motivation
- Make the editor display a splash/logo while booting so users see branding immediately during long initialization. 
- Prevent the main GLFW window from appearing before Vulkan/renderer/UI are ready to avoid flicker or unfinished UI. 
- Ensure splash resources are cleaned up on failure or shutdown to avoid leaks. 

### Description
- Add `ShowSplashScreen()` and `HideSplashScreen()` (Windows-only under `#ifdef _WIN32`) and store splash handles in `m_SplashWindow` and `m_SplashIcon` in `Application.h` and `Application.cpp`.
- Implement a lightweight Win32 splash window class (`LucentSplashWindow`) with a simple paint handler that draws the app icon and register/create/destroy logic in `Application::ShowSplashScreen()`/`HideSplashScreen()`.
- Hide the GLFW main window during init by adding `glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE)` in `InitWindow()` and call `glfwShowWindow(m_Window)` and `glfwFocusWindow(m_Window)` after initialization completes.
- Call `HideSplashScreen()` on any initialization error paths and during `Shutdown()` to ensure resources are released.

### Testing
- No automated tests were run for this change.
- The patch was applied and the modified files are `app/editor/include/Application.h` and `app/editor/src/Application.cpp` as updated in this PR.
- Windows-specific behavior is gated with `#ifdef _WIN32` so non-Windows builds remain unaffected.
- Manual runtime verification is recommended on Windows to confirm the splash shows and the main window appears after initialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbb2f0fb0832c955422dadb14e90c)